### PR TITLE
Fix error when closing socket via resource guard. Bump to 0.9.1

### DIFF
--- a/lib/membrane_udp/common_socket_behaviour.ex
+++ b/lib/membrane_udp/common_socket_behaviour.ex
@@ -19,7 +19,7 @@ defmodule Membrane.UDP.CommonSocketBehaviour do
 
         Membrane.ResourceGuard.register(
           ctx.resource_guard,
-          fn -> close_socket(local_socket) end,
+          fn -> close_socket(socket) end,
           tag: :udp_guard
         )
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.UDP.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.9.1"
   @github_url "https://github.com/membraneframework/membrane_udp_plugin"
 
   def project do
@@ -45,7 +45,7 @@ defmodule Membrane.UDP.MixProject do
       licenses: ["Apache-2.0"],
       links: %{
         "GitHub" => @github_url,
-        "Membrane Framework Homepage" => "https://membraneframework.org"
+        "Membrane Framework Homepage" => "https://membrane.stream"
       }
     ]
   end

--- a/test/membrane_udp/common_behaviour_test.exs
+++ b/test/membrane_udp/common_behaviour_test.exs
@@ -30,7 +30,8 @@ defmodule Membrane.UDP.CommonBehaviourTest do
       # socket down
       mock(Socket, [close: 1], %Socket{socket | socket_handle: nil})
       close_socket.()
-      assert_called(Socket, close: 1)
+      self_pid = self()
+      assert_called(Socket, :close, [%{socket_handle: ^self_pid}])
     end
   end
 end


### PR DESCRIPTION
When closing socket via resource guard, the following error would occur:
```elixir
17:23:32.249 [error] Task #PID<0.537.0> started from #PID<0.516.0> terminating
** (FunctionClauseError) no function clause matching in Membrane.UDP.Socket.close/1
    (membrane_udp_plugin 0.9.0) lib/membrane_udp/socket.ex:33: Membrane.UDP.Socket.close(%Membrane.UDP.Socket{port_no: 20000, ip_address: :any, socket_handle: nil, sock_opts: [recbuf: 500000]})
    (elixir 1.14.2) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: #Function<0.36759895/0 in Membrane.UDP.CommonSocketBehaviour.handle_setup/2>
    Args: []

17:23:32.251 [error] Error cleaning up resource with tag: :udp_guard, due to: {:function_clause, [{Membrane.UDP.Socket, :close, [%Membrane.UDP.Socket{port_no: 20000, ip_address: :any, socket_handle: nil, sock_opts: [recbuf: 500000]}], [file: 'lib/membrane_udp/socket.ex', line: 33]}, {Task.Supervised, :invoke_mfa, 2, [file: 'lib/task/supervised.ex', line: 89]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]}
```

This was caused by using the not-yet-updated socket struct in the guard, with `socket_handle: nil`.