### PR TITLE
Add pierce NAT functionality. Bump to 0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides UDP Source and Sink, that read and write to UDP sockets.
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-	{:membrane_udp_plugin, "~> 0.9.0"}
+	{:membrane_udp_plugin, "~> 0.9.2"}
 ```
 
 ## Usage example

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.UDP.MixProject do
   use Mix.Project
 
-  @version "0.9.1"
+  @version "0.9.2"
   @github_url "https://github.com/membraneframework/membrane_udp_plugin"
 
   def project do


### PR DESCRIPTION
This will be used by `membrane_rtc_engine`'s new RTSP Endpoint, and possibly other things in the future.

I'm not entirely satisfied with this solution, but it is what it is.