### PR TITLE
Add :set_destination parent notification and :latch? option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides UDP Source and Sink, that read and write to UDP sockets.
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-	{:membrane_udp_plugin, "~> 0.14.2"}
+	{:membrane_udp_plugin, "~> 0.14.3"}
 ```
 
 ## Usage example

--- a/lib/membrane_udp/common_socket_behaviour.ex
+++ b/lib/membrane_udp/common_socket_behaviour.ex
@@ -49,4 +49,19 @@ defmodule Membrane.UDP.CommonSocketBehaviour do
   defp close_socket(%Socket{} = local_socket) do
     Socket.close(local_socket)
   end
+
+  @spec validate_destination!(:inet.ip_address(), :inet.port_number()) :: :ok
+  def validate_destination!(ip, port) do
+    unless is_tuple(ip) and tuple_size(ip) in [4, 8] do
+      raise ArgumentError,
+            "expected an :inet.ip_address() tuple, got: #{inspect(ip)}"
+    end
+
+    unless is_integer(port) and port in 1..65_535 do
+      raise ArgumentError,
+            "expected a UDP port in 1..65535, got: #{inspect(port)}"
+    end
+
+    :ok
+  end
 end

--- a/lib/membrane_udp/common_socket_behaviour.ex
+++ b/lib/membrane_udp/common_socket_behaviour.ex
@@ -5,6 +5,8 @@ defmodule Membrane.UDP.CommonSocketBehaviour do
   alias Membrane.Element.CallbackContext
   alias Membrane.UDP.Socket
 
+  @type destination_port :: 1..65_535
+
   @spec handle_setup(
           context :: CallbackContext.t(),
           state :: Element.state()
@@ -50,7 +52,7 @@ defmodule Membrane.UDP.CommonSocketBehaviour do
     Socket.close(local_socket)
   end
 
-  @spec validate_destination!(:inet.ip_address(), :inet.port_number()) :: :ok
+  @spec validate_destination!(:inet.ip_address(), destination_port()) :: :ok
   def validate_destination!(ip, port) do
     unless is_tuple(ip) and tuple_size(ip) in [4, 8] do
       raise ArgumentError,

--- a/lib/membrane_udp/common_socket_behaviour.ex
+++ b/lib/membrane_udp/common_socket_behaviour.ex
@@ -5,8 +5,6 @@ defmodule Membrane.UDP.CommonSocketBehaviour do
   alias Membrane.Element.CallbackContext
   alias Membrane.UDP.Socket
 
-  @type destination_port :: 1..65_535
-
   @spec handle_setup(
           context :: CallbackContext.t(),
           state :: Element.state()
@@ -52,7 +50,10 @@ defmodule Membrane.UDP.CommonSocketBehaviour do
     Socket.close(local_socket)
   end
 
-  @spec validate_destination!(:inet.ip_address(), destination_port()) :: :ok
+  @spec validate_destination!(
+          :inet.ip_address(),
+          Membrane.UDP.Endpoint.destination_port() | Membrane.UDP.Sink.destination_port()
+        ) :: :ok
   def validate_destination!(ip, port) do
     unless is_tuple(ip) and tuple_size(ip) in [4, 8] do
       raise ArgumentError,

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -3,28 +3,27 @@ defmodule Membrane.UDP.Endpoint do
   Element that sends buffers received on the input pad over a UDP socket and
   reads packets from a UDP socket and sends their payloads through the output pad.
 
-  The destination can be changed at runtime by sending a parent notification:
+  The local and destination addresses are provided at init via the element's
+  options; the destination can additionally be changed at runtime by returning
+  a `:notify_child` action with a `t:set_destination_notification/0`:
 
-      {:notify_child, {:endpoint, {:set_destination, {1, 2, 3, 4}, 5000}}}
+      {[notify_child: {:endpoint, {:set_destination, peer_ip, peer_port}}], state}
   """
   use Membrane.Endpoint, flow_control_hints?: false
 
   alias Membrane.{Buffer, RemoteStream}
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
+  @type set_destination_notification ::
+          {:set_destination, :inet.ip_address(), :inet.port_number()}
+
   def_options destination_address: [
                 spec: :inet.ip_address(),
-                description: """
-                An IP Address that the packets will be sent to.
-                Can be updated at runtime via the `:set_destination` parent notification.
-                """
+                description: "An IP Address that the packets will be sent to."
               ],
               destination_port_no: [
                 spec: :inet.port_number(),
-                description: """
-                A UDP port number of a target.
-                Can be updated at runtime via the `:set_destination` parent notification.
-                """
+                description: "A UDP port number of a target."
               ],
               local_address: [
                 spec: :inet.socket_address(),
@@ -65,6 +64,8 @@ defmodule Membrane.UDP.Endpoint do
       local_address: local_address,
       local_port_no: local_port_no
     } = opts
+
+    CommonSocketBehaviour.validate_destination!(dst_address, dst_port_no)
 
     state = %{
       dst_socket: %Socket{

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -7,7 +7,9 @@ defmodule Membrane.UDP.Endpoint do
   options; the destination can additionally be changed at runtime by returning
   a `:notify_child` action with a `t:set_destination_notification/0`:
 
-      {[notify_child: {:endpoint, {:set_destination, peer_ip, peer_port}}], state}
+  ```elixir
+  {[notify_child: {:endpoint, {:set_destination, peer_ip, peer_port}}], state}
+  ```
   """
   use Membrane.Endpoint, flow_control_hints?: false
 

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -5,7 +5,7 @@ defmodule Membrane.UDP.Endpoint do
 
   The local and destination addresses are provided at init via the element's
   options; the destination can additionally be changed at runtime by returning
-  a `:notify_child` action with a `t:set_destination_notification/0`:
+  a `:notify_child` action with a `t:set_destination_notification/0` from the parents callback:
 
   ```elixir
   {[notify_child: {:endpoint, {:set_destination, peer_ip, peer_port}}], state}

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -10,6 +10,12 @@ defmodule Membrane.UDP.Endpoint do
   ```elixir
   {[notify_child: {:endpoint, {:set_destination, peer_ip, peer_port}}], state}
   ```
+
+  With `latch?: true`, the outbound destination automatically follows the
+  source of the most recent inbound packet. This is useful for talking to
+  peers whose source address may differ from the initially configured
+  destination (e.g. peers behind NAT) or change over time (e.g. mobile peers
+  roaming networks).
   """
   use Membrane.Endpoint, flow_control_hints?: false
 
@@ -50,6 +56,16 @@ defmodule Membrane.UDP.Endpoint do
                 description: """
                 Size of the receive buffer. Packages of size greater than this buffer will be truncated
                 """
+              ],
+              latch?: [
+                spec: boolean(),
+                default: false,
+                description: """
+                When true, the outbound destination follows the source of the most
+                recent inbound packet. Until the first inbound packet arrives,
+                outbound goes to the configured destination (the `destination_*`
+                options, possibly overridden via `:set_destination`).
+                """
               ]
 
   def_input_pad :input, accepted_format: _any
@@ -78,7 +94,8 @@ defmodule Membrane.UDP.Endpoint do
         ip_address: local_address,
         port_no: local_port_no,
         sock_opts: [recbuf: opts.recv_buffer_size]
-      }
+      },
+      latch?: opts.latch?
     }
 
     {[], state}
@@ -133,6 +150,15 @@ defmodule Membrane.UDP.Endpoint do
       |> Map.put(:arrival_ts, Membrane.Time.vm_time())
 
     actions = [buffer: {:output, %Buffer{payload: payload, metadata: metadata}}]
+
+    state =
+      if state.latch? do
+        state
+        |> put_in([:dst_socket, :ip_address], address)
+        |> put_in([:dst_socket, :port_no], port_no)
+      else
+        state
+      end
 
     {actions, state}
   end

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -23,14 +23,14 @@ defmodule Membrane.UDP.Endpoint do
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
   @type set_destination_notification ::
-          {:set_destination, :inet.ip_address(), :inet.port_number()}
+          {:set_destination, :inet.ip_address(), CommonSocketBehaviour.destination_port()}
 
   def_options destination_address: [
                 spec: :inet.ip_address(),
                 description: "An IP Address that the packets will be sent to."
               ],
               destination_port_no: [
-                spec: :inet.port_number(),
+                spec: CommonSocketBehaviour.destination_port(),
                 description: "A UDP port number of a target."
               ],
               local_address: [
@@ -83,7 +83,7 @@ defmodule Membrane.UDP.Endpoint do
       local_port_no: local_port_no
     } = opts
 
-    CommonSocketBehaviour.validate_destination!(dst_address, dst_port_no)
+    :ok = CommonSocketBehaviour.validate_destination!(dst_address, dst_port_no)
 
     state = %{
       dst_socket: %Socket{
@@ -118,7 +118,7 @@ defmodule Membrane.UDP.Endpoint do
 
   @impl true
   def handle_parent_notification({:set_destination, ip, port}, _ctx, state) do
-    CommonSocketBehaviour.validate_destination!(ip, port)
+    :ok = CommonSocketBehaviour.validate_destination!(ip, port)
 
     state =
       state

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -14,11 +14,17 @@ defmodule Membrane.UDP.Endpoint do
 
   def_options destination_address: [
                 spec: :inet.ip_address(),
-                description: "An IP Address that the packets will be sent to."
+                description: """
+                An IP Address that the packets will be sent to.
+                Can be updated at runtime via the `:set_destination` parent notification.
+                """
               ],
               destination_port_no: [
                 spec: :inet.port_number(),
-                description: "A UDP port number of a target."
+                description: """
+                A UDP port number of a target.
+                Can be updated at runtime via the `:set_destination` parent notification.
+                """
               ],
               local_address: [
                 spec: :inet.socket_address(),

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -22,15 +22,17 @@ defmodule Membrane.UDP.Endpoint do
   alias Membrane.{Buffer, RemoteStream}
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
+  @type destination_port :: 1..65_535
+
   @type set_destination_notification ::
-          {:set_destination, :inet.ip_address(), CommonSocketBehaviour.destination_port()}
+          {:set_destination, :inet.ip_address(), destination_port()}
 
   def_options destination_address: [
                 spec: :inet.ip_address(),
                 description: "An IP Address that the packets will be sent to."
               ],
               destination_port_no: [
-                spec: CommonSocketBehaviour.destination_port(),
+                spec: destination_port(),
                 description: "A UDP port number of a target."
               ],
               local_address: [

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -19,6 +19,8 @@ defmodule Membrane.UDP.Endpoint do
   """
   use Membrane.Endpoint, flow_control_hints?: false
 
+  require Membrane.Logger
+
   alias Membrane.{Buffer, RemoteStream}
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
@@ -122,6 +124,13 @@ defmodule Membrane.UDP.Endpoint do
   def handle_parent_notification({:set_destination, ip, port}, _ctx, state) do
     :ok = CommonSocketBehaviour.validate_destination!(ip, port)
 
+    if state.latch? do
+      Membrane.Logger.warning("""
+      #{inspect({:set_destination, ip, port})}} received while :latch? option was set to true;
+      the next inbound packet might overwrite this destination"
+      """)
+    end
+
     state =
       state
       |> put_in([:dst_socket, :ip_address], ip)
@@ -145,22 +154,27 @@ defmodule Membrane.UDP.Endpoint do
         %{playback: :playing},
         state
       ) do
-    metadata =
-      Map.new()
-      |> Map.put(:udp_source_address, address)
-      |> Map.put(:udp_source_port, port_no)
-      |> Map.put(:arrival_ts, Membrane.Time.vm_time())
-
-    actions = [buffer: {:output, %Buffer{payload: payload, metadata: metadata}}]
-
     state =
-      if state.latch? do
+      if state.latch? and
+           (state.dst_socket.ip_address != address or state.dst_socket.port_no != port_no) do
+        Membrane.Logger.debug(
+          "latch: outbound destination updated to #{:inet.ntoa(address)}:#{port_no}"
+        )
+
         state
         |> put_in([:dst_socket, :ip_address], address)
         |> put_in([:dst_socket, :port_no], port_no)
       else
         state
       end
+
+    metadata = %{
+      udp_source_address: address,
+      udp_source_port: port_no,
+      arrival_ts: Membrane.Time.vm_time()
+    }
+
+    actions = [buffer: {:output, %Buffer{payload: payload, metadata: metadata}}]
 
     {actions, state}
   end

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -6,11 +6,6 @@ defmodule Membrane.UDP.Endpoint do
   The destination can be changed at runtime by sending a parent notification:
 
       {:notify_child, {:endpoint, {:set_destination, {1, 2, 3, 4}, 5000}}}
-
-  This is useful for symmetric-RTP latching: a pipeline can read the source
-  address from an incoming buffer's `:udp_source_address`/`:udp_source_port`
-  metadata and redirect subsequent outbound packets to that peer so replies
-  traverse NAT correctly.
   """
   use Membrane.Endpoint, flow_control_hints?: false
 
@@ -101,8 +96,8 @@ defmodule Membrane.UDP.Endpoint do
 
     state =
       state
-      |> put_in([:dst_socket, Access.key!(:ip_address)], ip)
-      |> put_in([:dst_socket, Access.key!(:port_no)], port)
+      |> put_in([:dst_socket, :ip_address], ip)
+      |> put_in([:dst_socket, :port_no], port)
 
     {[], state}
   end

--- a/lib/membrane_udp/endpoint.ex
+++ b/lib/membrane_udp/endpoint.ex
@@ -2,6 +2,15 @@ defmodule Membrane.UDP.Endpoint do
   @moduledoc """
   Element that sends buffers received on the input pad over a UDP socket and
   reads packets from a UDP socket and sends their payloads through the output pad.
+
+  The destination can be changed at runtime by sending a parent notification:
+
+      {:notify_child, {:endpoint, {:set_destination, {1, 2, 3, 4}, 5000}}}
+
+  This is useful for symmetric-RTP latching: a pipeline can read the source
+  address from an incoming buffer's `:udp_source_address`/`:udp_source_port`
+  metadata and redirect subsequent outbound packets to that peer so replies
+  traverse NAT correctly.
   """
   use Membrane.Endpoint, flow_control_hints?: false
 
@@ -84,6 +93,18 @@ defmodule Membrane.UDP.Endpoint do
       :ok -> {[], state}
       {:error, cause} -> raise "Error sending UDP packet, reason: #{inspect(cause)}"
     end
+  end
+
+  @impl true
+  def handle_parent_notification({:set_destination, ip, port}, _ctx, state) do
+    CommonSocketBehaviour.validate_destination!(ip, port)
+
+    state =
+      state
+      |> put_in([:dst_socket, Access.key!(:ip_address)], ip)
+      |> put_in([:dst_socket, Access.key!(:port_no)], port)
+
+    {[], state}
   end
 
   @impl true

--- a/lib/membrane_udp/sink.ex
+++ b/lib/membrane_udp/sink.ex
@@ -15,15 +15,17 @@ defmodule Membrane.UDP.Sink do
   alias Membrane.Buffer
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
+  @type destination_port :: 1..65_535
+
   @type set_destination_notification ::
-          {:set_destination, :inet.ip_address(), CommonSocketBehaviour.destination_port()}
+          {:set_destination, :inet.ip_address(), destination_port()}
 
   def_options destination_address: [
                 spec: :inet.ip_address(),
                 description: "An IP Address that the packets will be sent to."
               ],
               destination_port_no: [
-                spec: CommonSocketBehaviour.destination_port(),
+                spec: destination_port(),
                 description: "A UDP port number of a target."
               ],
               local_address: [

--- a/lib/membrane_udp/sink.ex
+++ b/lib/membrane_udp/sink.ex
@@ -13,11 +13,17 @@ defmodule Membrane.UDP.Sink do
 
   def_options destination_address: [
                 spec: :inet.ip_address(),
-                description: "An IP Address that the packets will be sent to."
+                description: """
+                An IP Address that the packets will be sent to.
+                Can be updated at runtime via the `:set_destination` parent notification.
+                """
               ],
               destination_port_no: [
                 spec: :inet.port_number(),
-                description: "A UDP port number of a target."
+                description: """
+                A UDP port number of a target.
+                Can be updated at runtime via the `:set_destination` parent notification.
+                """
               ],
               local_address: [
                 spec: :inet.socket_address(),

--- a/lib/membrane_udp/sink.ex
+++ b/lib/membrane_udp/sink.ex
@@ -94,8 +94,8 @@ defmodule Membrane.UDP.Sink do
 
     state =
       state
-      |> put_in([:dst_socket, Access.key!(:ip_address)], ip)
-      |> put_in([:dst_socket, Access.key!(:port_no)], port)
+      |> put_in([:dst_socket, :ip_address], ip)
+      |> put_in([:dst_socket, :port_no], port)
 
     {[], state}
   end

--- a/lib/membrane_udp/sink.ex
+++ b/lib/membrane_udp/sink.ex
@@ -6,7 +6,9 @@ defmodule Membrane.UDP.Sink do
   options; the destination can additionally be changed at runtime by returning
   a `:notify_child` action with a `t:set_destination_notification/0`:
 
-      {[notify_child: {:sink, {:set_destination, peer_ip, peer_port}}], state}
+  ```elixir
+  {[notify_child: {:sink, {:set_destination, peer_ip, peer_port}}], state}
+  ```
   """
   use Membrane.Sink
 

--- a/lib/membrane_udp/sink.ex
+++ b/lib/membrane_udp/sink.ex
@@ -16,14 +16,14 @@ defmodule Membrane.UDP.Sink do
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
   @type set_destination_notification ::
-          {:set_destination, :inet.ip_address(), :inet.port_number()}
+          {:set_destination, :inet.ip_address(), CommonSocketBehaviour.destination_port()}
 
   def_options destination_address: [
                 spec: :inet.ip_address(),
                 description: "An IP Address that the packets will be sent to."
               ],
               destination_port_no: [
-                spec: :inet.port_number(),
+                spec: CommonSocketBehaviour.destination_port(),
                 description: "A UDP port number of a target."
               ],
               local_address: [
@@ -65,7 +65,7 @@ defmodule Membrane.UDP.Sink do
       local_socket: local_socket
     } = options
 
-    CommonSocketBehaviour.validate_destination!(dst_address, dst_port_no)
+    :ok = CommonSocketBehaviour.validate_destination!(dst_address, dst_port_no)
 
     state = %{
       dst_socket: %Socket{
@@ -99,7 +99,7 @@ defmodule Membrane.UDP.Sink do
 
   @impl true
   def handle_parent_notification({:set_destination, ip, port}, _ctx, state) do
-    CommonSocketBehaviour.validate_destination!(ip, port)
+    :ok = CommonSocketBehaviour.validate_destination!(ip, port)
 
     state =
       state

--- a/lib/membrane_udp/sink.ex
+++ b/lib/membrane_udp/sink.ex
@@ -1,6 +1,10 @@
 defmodule Membrane.UDP.Sink do
   @moduledoc """
   Element that sends buffers received on the input pad over a UDP socket.
+
+  The destination can be changed at runtime by sending a parent notification:
+
+      {:notify_child, {:sink, {:set_destination, {1, 2, 3, 4}, 5000}}}
   """
   use Membrane.Sink
 
@@ -82,6 +86,18 @@ defmodule Membrane.UDP.Sink do
       :ok -> {[], state}
       {:error, cause} -> raise "Error sending UDP packet, reason: #{inspect(cause)}"
     end
+  end
+
+  @impl true
+  def handle_parent_notification({:set_destination, ip, port}, _ctx, state) do
+    CommonSocketBehaviour.validate_destination!(ip, port)
+
+    state =
+      state
+      |> put_in([:dst_socket, Access.key!(:ip_address)], ip)
+      |> put_in([:dst_socket, Access.key!(:port_no)], port)
+
+    {[], state}
   end
 
   @impl true

--- a/lib/membrane_udp/sink.ex
+++ b/lib/membrane_udp/sink.ex
@@ -2,28 +2,27 @@ defmodule Membrane.UDP.Sink do
   @moduledoc """
   Element that sends buffers received on the input pad over a UDP socket.
 
-  The destination can be changed at runtime by sending a parent notification:
+  The local and destination addresses are provided at init via the element's
+  options; the destination can additionally be changed at runtime by returning
+  a `:notify_child` action with a `t:set_destination_notification/0`:
 
-      {:notify_child, {:sink, {:set_destination, {1, 2, 3, 4}, 5000}}}
+      {[notify_child: {:sink, {:set_destination, peer_ip, peer_port}}], state}
   """
   use Membrane.Sink
 
   alias Membrane.Buffer
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
+  @type set_destination_notification ::
+          {:set_destination, :inet.ip_address(), :inet.port_number()}
+
   def_options destination_address: [
                 spec: :inet.ip_address(),
-                description: """
-                An IP Address that the packets will be sent to.
-                Can be updated at runtime via the `:set_destination` parent notification.
-                """
+                description: "An IP Address that the packets will be sent to."
               ],
               destination_port_no: [
                 spec: :inet.port_number(),
-                description: """
-                A UDP port number of a target.
-                Can be updated at runtime via the `:set_destination` parent notification.
-                """
+                description: "A UDP port number of a target."
               ],
               local_address: [
                 spec: :inet.socket_address(),
@@ -63,6 +62,8 @@ defmodule Membrane.UDP.Sink do
       local_port_no: local_port_no,
       local_socket: local_socket
     } = options
+
+    CommonSocketBehaviour.validate_destination!(dst_address, dst_port_no)
 
     state = %{
       dst_socket: %Socket{

--- a/lib/membrane_udp/socket.ex
+++ b/lib/membrane_udp/socket.ex
@@ -1,6 +1,8 @@
 defmodule Membrane.UDP.Socket do
   @moduledoc false
 
+  use Bunch.Access
+
   @enforce_keys [:port_no, :ip_address]
   defstruct [:port_no, :ip_address, :socket_handle, sock_opts: []]
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.UDP.MixProject do
   use Mix.Project
 
-  @version "0.14.2"
+  @version "0.14.3"
   @github_url "https://github.com/membraneframework/membrane_udp_plugin"
 
   def project do

--- a/test/membrane_udp/common_behaviour_test.exs
+++ b/test/membrane_udp/common_behaviour_test.exs
@@ -7,6 +7,39 @@ defmodule Membrane.UDP.CommonBehaviourTest do
   alias Membrane.UDP.{CommonSocketBehaviour, Socket}
 
   describe "CommonBehaviour" do
+    test "validate_destination! accepts valid IPv4 and IPv6 with valid port" do
+      assert :ok = CommonSocketBehaviour.validate_destination!({127, 0, 0, 1}, 5000)
+      assert :ok = CommonSocketBehaviour.validate_destination!({0, 0, 0, 0, 0, 0, 0, 1}, 5000)
+      assert :ok = CommonSocketBehaviour.validate_destination!({1, 2, 3, 4}, 1)
+      assert :ok = CommonSocketBehaviour.validate_destination!({1, 2, 3, 4}, 65_535)
+    end
+
+    test "validate_destination! rejects non-tuple ip" do
+      assert_raise ArgumentError, ~r/ip_address/, fn ->
+        CommonSocketBehaviour.validate_destination!("127.0.0.1", 5000)
+      end
+    end
+
+    test "validate_destination! rejects ip tuples of wrong size" do
+      assert_raise ArgumentError, ~r/ip_address/, fn ->
+        CommonSocketBehaviour.validate_destination!({1, 2, 3}, 5000)
+      end
+    end
+
+    test "validate_destination! rejects out-of-range ports" do
+      assert_raise ArgumentError, ~r/UDP port/, fn ->
+        CommonSocketBehaviour.validate_destination!({127, 0, 0, 1}, 0)
+      end
+
+      assert_raise ArgumentError, ~r/UDP port/, fn ->
+        CommonSocketBehaviour.validate_destination!({127, 0, 0, 1}, 65_536)
+      end
+
+      assert_raise ArgumentError, ~r/UDP port/, fn ->
+        CommonSocketBehaviour.validate_destination!({127, 0, 0, 1}, :not_a_port)
+      end
+    end
+
     test "opens and close socket when transitioning through states" do
       # socket up
       socket = %Socket{port_no: 123, ip_address: {127, 0, 0, 1}}

--- a/test/membrane_udp/integration_test.exs
+++ b/test/membrane_udp/integration_test.exs
@@ -8,6 +8,26 @@ defmodule Membrane.UDP.IntegrationTest do
   alias Membrane.Testing.Pipeline
   alias Membrane.UDP
 
+  defmodule PushSource do
+    @moduledoc false
+    use Membrane.Source
+
+    def_output_pad :output, accepted_format: _any, flow_control: :push
+
+    @impl true
+    def handle_init(_ctx, _opts), do: {[], %{}}
+
+    @impl true
+    def handle_playing(_ctx, state) do
+      {[stream_format: {:output, %Membrane.RemoteStream{type: :packetized}}], state}
+    end
+
+    @impl true
+    def handle_parent_notification({:push, payload}, _ctx, state) do
+      {[buffer: {:output, %Membrane.Buffer{payload: payload}}], state}
+    end
+  end
+
   @target_port 5000
   @server_port 6789
   @localhostv4 {127, 0, 0, 1}
@@ -85,6 +105,55 @@ defmodule Membrane.UDP.IntegrationTest do
     end)
 
     Pipeline.terminate(pipeline)
+  end
+
+  for {element, base_port} <- [{UDP.Endpoint, 6100}, {UDP.Sink, 6200}] do
+    test ":set_destination at runtime redirects packets through #{inspect(element)}" do
+      initial_port = unquote(base_port) + 1
+      new_port = unquote(base_port) + 2
+
+      {:ok, probe_initial} =
+        :gen_udp.open(initial_port, [:binary, ip: @localhostv4, active: true])
+
+      {:ok, probe_new} =
+        :gen_udp.open(new_port, [:binary, ip: @localhostv4, active: true])
+
+      udp_child =
+        struct!(unquote(element), %{
+          local_port_no: 0,
+          local_address: @localhostv4,
+          destination_port_no: initial_port,
+          destination_address: @localhostv4
+        })
+
+      base_link = child(:source, PushSource) |> child(:udp, udp_child)
+
+      spec =
+        if unquote(element) == UDP.Endpoint do
+          [base_link |> child(:drop, %Testing.Sink{})]
+        else
+          [base_link]
+        end
+
+      pipeline = Pipeline.start_link_supervised!(spec: spec)
+
+      assert_pipeline_notified(pipeline, :udp, {:connection_info, _addr, _port})
+
+      Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "first"}})
+      assert_receive {:udp, ^probe_initial, @localhostv4, _from_port, "first"}, 2000
+
+      Pipeline.execute_actions(pipeline,
+        notify_child: {:udp, {:set_destination, @localhostv4, new_port}}
+      )
+
+      Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "second"}})
+      assert_receive {:udp, ^probe_new, @localhostv4, _from_port, "second"}, 2000
+      refute_receive {:udp, ^probe_initial, _, _, "second"}, 100
+
+      :gen_udp.close(probe_initial)
+      :gen_udp.close(probe_new)
+      Pipeline.terminate(pipeline)
+    end
   end
 
   test "NAT pierce datagram comes through" do

--- a/test/membrane_udp/integration_test.exs
+++ b/test/membrane_udp/integration_test.exs
@@ -107,10 +107,10 @@ defmodule Membrane.UDP.IntegrationTest do
     Pipeline.terminate(pipeline)
   end
 
-  for {element, base_port} <- [{UDP.Endpoint, 6100}, {UDP.Sink, 6200}] do
+  for element <- [UDP.Endpoint, UDP.Sink] do
     test ":set_destination at runtime redirects packets through #{inspect(element)}" do
-      initial_port = unquote(base_port) + 1
-      new_port = unquote(base_port) + 2
+      initial_port = get_free_port()
+      new_port = get_free_port()
 
       {:ok, probe_initial} =
         :gen_udp.open(initial_port, [:binary, ip: @localhostv4, active: true])
@@ -159,53 +159,11 @@ defmodule Membrane.UDP.IntegrationTest do
     end
   end
 
-  test "latch?: false keeps the configured destination after an inbound packet" do
-    endpoint_port = 6310
-    port_a = 6311
-    port_b = 6312
-
-    {:ok, probe_a} = :gen_udp.open(port_a, [:binary, ip: @localhostv4, active: true])
-    {:ok, probe_b} = :gen_udp.open(port_b, [:binary, ip: @localhostv4, active: true])
-
-    on_exit(fn ->
-      :gen_udp.close(probe_a)
-      :gen_udp.close(probe_b)
-    end)
-
-    pipeline =
-      Pipeline.start_link_supervised!(
-        spec:
-          child(:source, PushSource)
-          |> child(:udp, %UDP.Endpoint{
-            local_port_no: endpoint_port,
-            local_address: @localhostv4,
-            destination_port_no: port_a,
-            destination_address: @localhostv4,
-            latch?: false
-          })
-          |> child(:sink, %Testing.Sink{})
-      )
-
-    assert_pipeline_notified(pipeline, :udp, {:connection_info, _addr, _port})
-
-    Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "to_a"}})
-    assert_receive {:udp, ^probe_a, @localhostv4, _from, "to_a"}, 2000
-
-    :gen_udp.send(probe_b, @localhostv4, endpoint_port, "from_b")
-    assert_sink_buffer(pipeline, :sink, %Buffer{payload: "from_b"})
-
-    Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "still_a"}})
-    assert_receive {:udp, ^probe_a, @localhostv4, _from, "still_a"}, 2000
-    refute_receive {:udp, ^probe_b, _, _, "still_a"}, 100
-
-    Pipeline.terminate(pipeline)
-  end
-
-  test "latch?: true makes the destination follow the most recent inbound packet" do
-    endpoint_port = 6320
-    port_a = 6321
-    port_b = 6322
-    port_c = 6323
+  test "latch?: true makes the outbound destination follow the source of the most recent inbound packet" do
+    endpoint_port = get_free_port()
+    port_a = get_free_port()
+    port_b = get_free_port()
+    port_c = get_free_port()
 
     {:ok, probe_a} = :gen_udp.open(port_a, [:binary, ip: @localhostv4, active: true])
     {:ok, probe_b} = :gen_udp.open(port_b, [:binary, ip: @localhostv4, active: true])
@@ -277,5 +235,12 @@ defmodule Membrane.UDP.IntegrationTest do
 
     handle = server_sock.socket_handle
     assert_receive({:udp, ^handle, @localhostv4, @target_port, <<>>}, 20_000)
+  end
+
+  defp get_free_port() do
+    {:ok, s} = :gen_tcp.listen(0, active: false)
+    {:ok, port} = :inet.port(s)
+    :ok = :gen_tcp.close(s)
+    port
   end
 end

--- a/test/membrane_udp/integration_test.exs
+++ b/test/membrane_udp/integration_test.exs
@@ -159,6 +159,101 @@ defmodule Membrane.UDP.IntegrationTest do
     end
   end
 
+  test "latch?: false keeps the configured destination after an inbound packet" do
+    endpoint_port = 6310
+    port_a = 6311
+    port_b = 6312
+
+    {:ok, probe_a} = :gen_udp.open(port_a, [:binary, ip: @localhostv4, active: true])
+    {:ok, probe_b} = :gen_udp.open(port_b, [:binary, ip: @localhostv4, active: true])
+
+    on_exit(fn ->
+      :gen_udp.close(probe_a)
+      :gen_udp.close(probe_b)
+    end)
+
+    pipeline =
+      Pipeline.start_link_supervised!(
+        spec:
+          child(:source, PushSource)
+          |> child(:udp, %UDP.Endpoint{
+            local_port_no: endpoint_port,
+            local_address: @localhostv4,
+            destination_port_no: port_a,
+            destination_address: @localhostv4,
+            latch?: false
+          })
+          |> child(:sink, %Testing.Sink{})
+      )
+
+    assert_pipeline_notified(pipeline, :udp, {:connection_info, _addr, _port})
+
+    Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "to_a"}})
+    assert_receive {:udp, ^probe_a, @localhostv4, _from, "to_a"}, 2000
+
+    :gen_udp.send(probe_b, @localhostv4, endpoint_port, "from_b")
+    assert_sink_buffer(pipeline, :sink, %Buffer{payload: "from_b"})
+
+    Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "still_a"}})
+    assert_receive {:udp, ^probe_a, @localhostv4, _from, "still_a"}, 2000
+    refute_receive {:udp, ^probe_b, _, _, "still_a"}, 100
+
+    Pipeline.terminate(pipeline)
+  end
+
+  test "latch?: true makes the destination follow the most recent inbound packet" do
+    endpoint_port = 6320
+    port_a = 6321
+    port_b = 6322
+    port_c = 6323
+
+    {:ok, probe_a} = :gen_udp.open(port_a, [:binary, ip: @localhostv4, active: true])
+    {:ok, probe_b} = :gen_udp.open(port_b, [:binary, ip: @localhostv4, active: true])
+    {:ok, probe_c} = :gen_udp.open(port_c, [:binary, ip: @localhostv4, active: true])
+
+    on_exit(fn ->
+      :gen_udp.close(probe_a)
+      :gen_udp.close(probe_b)
+      :gen_udp.close(probe_c)
+    end)
+
+    pipeline =
+      Pipeline.start_link_supervised!(
+        spec:
+          child(:source, PushSource)
+          |> child(:udp, %UDP.Endpoint{
+            local_port_no: endpoint_port,
+            local_address: @localhostv4,
+            destination_port_no: port_a,
+            destination_address: @localhostv4,
+            latch?: true
+          })
+          |> child(:sink, %Testing.Sink{})
+      )
+
+    assert_pipeline_notified(pipeline, :udp, {:connection_info, _addr, _port})
+
+    Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "to_a"}})
+    assert_receive {:udp, ^probe_a, @localhostv4, _from, "to_a"}, 2000
+
+    :gen_udp.send(probe_b, @localhostv4, endpoint_port, "from_b")
+    assert_sink_buffer(pipeline, :sink, %Buffer{payload: "from_b"})
+
+    Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "to_b"}})
+    assert_receive {:udp, ^probe_b, @localhostv4, _from, "to_b"}, 2000
+    refute_receive {:udp, ^probe_a, _, _, "to_b"}, 100
+
+    :gen_udp.send(probe_c, @localhostv4, endpoint_port, "from_c")
+    assert_sink_buffer(pipeline, :sink, %Buffer{payload: "from_c"})
+
+    Pipeline.execute_actions(pipeline, notify_child: {:source, {:push, "to_c"}})
+    assert_receive {:udp, ^probe_c, @localhostv4, _from, "to_c"}, 2000
+    refute_receive {:udp, ^probe_a, _, _, "to_c"}, 100
+    refute_receive {:udp, ^probe_b, _, _, "to_c"}, 100
+
+    Pipeline.terminate(pipeline)
+  end
+
   test "NAT pierce datagram comes through" do
     {:ok, server_sock} =
       UDP.Socket.open(%UDP.Socket{port_no: @server_port, ip_address: @localhostv4})

--- a/test/membrane_udp/integration_test.exs
+++ b/test/membrane_udp/integration_test.exs
@@ -118,6 +118,11 @@ defmodule Membrane.UDP.IntegrationTest do
       {:ok, probe_new} =
         :gen_udp.open(new_port, [:binary, ip: @localhostv4, active: true])
 
+      on_exit(fn ->
+        :gen_udp.close(probe_initial)
+        :gen_udp.close(probe_new)
+      end)
+
       udp_child =
         struct!(unquote(element), %{
           local_port_no: 0,
@@ -130,9 +135,9 @@ defmodule Membrane.UDP.IntegrationTest do
 
       spec =
         if unquote(element) == UDP.Endpoint do
-          [base_link |> child(:drop, %Testing.Sink{})]
+          base_link |> child(:fake_sink, %Membrane.Debug.Sink{})
         else
-          [base_link]
+          base_link
         end
 
       pipeline = Pipeline.start_link_supervised!(spec: spec)
@@ -150,8 +155,6 @@ defmodule Membrane.UDP.IntegrationTest do
       assert_receive {:udp, ^probe_new, @localhostv4, _from_port, "second"}, 2000
       refute_receive {:udp, ^probe_initial, _, _, "second"}, 100
 
-      :gen_udp.close(probe_initial)
-      :gen_udp.close(probe_new)
       Pipeline.terminate(pipeline)
     end
   end

--- a/test/membrane_udp/sink/integration_test.exs
+++ b/test/membrane_udp/sink/integration_test.exs
@@ -14,7 +14,7 @@ defmodule Membrane.UDP.SinkIntegrationTest do
     dst_socket = %Socket{port_no: @destination_port_no, ip_address: @local_address}
     local_socket = %Socket{port_no: @local_port_no, ip_address: @local_address}
 
-    %{state: %{dst_socket: dst_socket, local_socket: local_socket}}
+    %{state: %{dst_socket: dst_socket, local_socket: local_socket, latch?: false}}
   end
 
   setup [:setup_state, :setup_socket_from_state]

--- a/test/membrane_udp/sink/integration_test.exs
+++ b/test/membrane_udp/sink/integration_test.exs
@@ -28,5 +28,32 @@ defmodule Membrane.UDP.SinkIntegrationTest do
 
       assert_receive {:udp, _, @local_address, @local_port_no, ^payload}
     end
+
+    @tag open_socket_from_state: [:dst_socket, :local_socket]
+    test ":set_destination redirects packets to the new port via #{inspect(module)}",
+         %{state: state} do
+      alt_port = @destination_port_no + 100
+
+      alt_socket =
+        SocketSetup.setup_socket(%Socket{port_no: alt_port, ip_address: @local_address})
+
+      alt_handle = alt_socket.socket_handle
+      dst_handle = state.dst_socket.socket_handle
+
+      unquote(module).handle_buffer(:input, %Buffer{payload: "before"}, nil, state)
+      assert_receive {:udp, ^dst_handle, @local_address, @local_port_no, "before"}
+
+      {[], new_state} =
+        unquote(module).handle_parent_notification(
+          {:set_destination, @local_address, alt_port},
+          nil,
+          state
+        )
+
+      unquote(module).handle_buffer(:input, %Buffer{payload: "after"}, nil, new_state)
+
+      assert_receive {:udp, ^alt_handle, @local_address, @local_port_no, "after"}
+      refute_receive {:udp, ^dst_handle, _, _, "after"}, 100
+    end
   end
 end

--- a/test/membrane_udp/sink/integration_test.exs
+++ b/test/membrane_udp/sink/integration_test.exs
@@ -14,14 +14,15 @@ defmodule Membrane.UDP.SinkIntegrationTest do
     dst_socket = %Socket{port_no: @destination_port_no, ip_address: @local_address}
     local_socket = %Socket{port_no: @local_port_no, ip_address: @local_address}
 
-    %{state: %{dst_socket: dst_socket, local_socket: local_socket, latch?: false}}
+    %{state: %{dst_socket: dst_socket, local_socket: local_socket}}
   end
 
   setup [:setup_state, :setup_socket_from_state]
 
-  for module <- [Endpoint, Sink] do
+  for {module, extra_state} <- [{Endpoint, %{latch?: false}}, {Sink, %{}}] do
     @tag open_socket_from_state: [:dst_socket, :local_socket]
     test "Sends udp packet through #{inspect(module)}", %{state: state} do
+      state = Map.merge(state, unquote(Macro.escape(extra_state)))
       payload = "A lot of laughs"
 
       unquote(module).handle_buffer(:input, %Buffer{payload: payload}, nil, state)
@@ -32,6 +33,7 @@ defmodule Membrane.UDP.SinkIntegrationTest do
     @tag open_socket_from_state: [:dst_socket, :local_socket]
     test ":set_destination redirects packets to the new port via #{inspect(module)}",
          %{state: state} do
+      state = Map.merge(state, unquote(Macro.escape(extra_state)))
       alt_port = @destination_port_no + 100
 
       alt_socket =

--- a/test/membrane_udp/sink/unit_test.exs
+++ b/test/membrane_udp/sink/unit_test.exs
@@ -23,48 +23,6 @@ defmodule Membrane.UDP.SinkUnitTest do
         assert unquote(module).handle_buffer(:input, %Buffer{payload: payload_data}, nil, state) ==
                  {[], state}
       end
-
-      test "handle_parent_notification/3 :set_destination updates dst_socket" do
-        local_socket = %Socket{port_no: 1234, ip_address: @local_address}
-        dst_socket = %Socket{port_no: 4321, ip_address: @local_address}
-        state = %{local_socket: local_socket, dst_socket: dst_socket}
-
-        new_ip = {1, 2, 3, 4}
-        new_port = 9000
-
-        assert {[], new_state} =
-                 unquote(module).handle_parent_notification(
-                   {:set_destination, new_ip, new_port},
-                   nil,
-                   state
-                 )
-
-        assert new_state.dst_socket.ip_address == new_ip
-        assert new_state.dst_socket.port_no == new_port
-        assert new_state.local_socket == local_socket
-      end
-
-      test "handle_parent_notification/3 :set_destination raises on bad input" do
-        local_socket = %Socket{port_no: 1234, ip_address: @local_address}
-        dst_socket = %Socket{port_no: 4321, ip_address: @local_address}
-        state = %{local_socket: local_socket, dst_socket: dst_socket}
-
-        assert_raise ArgumentError, fn ->
-          unquote(module).handle_parent_notification(
-            {:set_destination, "1.2.3.4", 9000},
-            nil,
-            state
-          )
-        end
-
-        assert_raise ArgumentError, fn ->
-          unquote(module).handle_parent_notification(
-            {:set_destination, {1, 2, 3, 4}, 70_000},
-            nil,
-            state
-          )
-        end
-      end
     end
   end
 end

--- a/test/membrane_udp/sink/unit_test.exs
+++ b/test/membrane_udp/sink/unit_test.exs
@@ -23,6 +23,48 @@ defmodule Membrane.UDP.SinkUnitTest do
         assert unquote(module).handle_buffer(:input, %Buffer{payload: payload_data}, nil, state) ==
                  {[], state}
       end
+
+      test "handle_parent_notification/3 :set_destination updates dst_socket" do
+        local_socket = %Socket{port_no: 1234, ip_address: @local_address}
+        dst_socket = %Socket{port_no: 4321, ip_address: @local_address}
+        state = %{local_socket: local_socket, dst_socket: dst_socket}
+
+        new_ip = {1, 2, 3, 4}
+        new_port = 9000
+
+        assert {[], new_state} =
+                 unquote(module).handle_parent_notification(
+                   {:set_destination, new_ip, new_port},
+                   nil,
+                   state
+                 )
+
+        assert new_state.dst_socket.ip_address == new_ip
+        assert new_state.dst_socket.port_no == new_port
+        assert new_state.local_socket == local_socket
+      end
+
+      test "handle_parent_notification/3 :set_destination raises on bad input" do
+        local_socket = %Socket{port_no: 1234, ip_address: @local_address}
+        dst_socket = %Socket{port_no: 4321, ip_address: @local_address}
+        state = %{local_socket: local_socket, dst_socket: dst_socket}
+
+        assert_raise ArgumentError, fn ->
+          unquote(module).handle_parent_notification(
+            {:set_destination, "1.2.3.4", 9000},
+            nil,
+            state
+          )
+        end
+
+        assert_raise ArgumentError, fn ->
+          unquote(module).handle_parent_notification(
+            {:set_destination, {1, 2, 3, 4}, 70_000},
+            nil,
+            state
+          )
+        end
+      end
     end
   end
 end

--- a/test/membrane_udp/source/unit_test.exs
+++ b/test/membrane_udp/source/unit_test.exs
@@ -8,7 +8,7 @@ defmodule Membrane.UDP.SourceTest do
       example_binary_payload = "Hi there, I am binary"
       sender_port = 6666
       sender_address = {192, 168, 0, 1}
-      state = :unchanged
+      state = %{latch?: false}
       message = {:udp, 5000, sender_address, sender_port, example_binary_payload}
 
       assert {actions, ^state} =

--- a/test/membrane_udp/source/unit_test.exs
+++ b/test/membrane_udp/source/unit_test.exs
@@ -3,12 +3,12 @@ defmodule Membrane.UDP.SourceTest do
 
   alias Membrane.UDP.{Endpoint, Source}
 
-  for module <- [Endpoint, Source] do
+  for {module, state_fixture} <- [{Endpoint, %{latch?: false}}, {Source, %{}}] do
     test "parses udp message #{inspect(module)} element" do
       example_binary_payload = "Hi there, I am binary"
       sender_port = 6666
       sender_address = {192, 168, 0, 1}
-      state = %{latch?: false}
+      state = unquote(Macro.escape(state_fixture))
       message = {:udp, 5000, sender_address, sender_port, example_binary_payload}
 
       assert {actions, ^state} =


### PR DESCRIPTION
Two additions for runtime-controlled outbound UDP destination:

- **`:set_destination` parent notification** on `Membrane.UDP.Endpoint` and `Membrane.UDP.Sink` — change the outbound destination at runtime without re-creating the element.
- **`latch?: true` option on `Membrane.UDP.Endpoint`** — outbound destination automatically follows the source of the most recent inbound packet. Useful for peers whose source address differs from the configured destination (NAT) or changes over time (mobile peers). Sink has no inbound side, so the option doesn't apply there.

The two compose on `Endpoint`: `:set_destination` is explicit, `latch?` is automatic. Whichever happened most recently wins.